### PR TITLE
Fix problem numbering in log

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,9 +65,10 @@ jobs:
               gasValue=$(echo "$problems" | jq -r ".[$i].gasValue")
               compiled=$(echo "$problems" | jq -r ".[$i].compiled")
               points=$(echo "$problems" | jq -r ".[$i].points")
+              order=$(echo "$problems" | jq -r ".[$i].order")
               compilationError=$(echo "$problems" | jq -r ".[$i].compilationError")
               echo ""
-              echo "Problem #$((i+1)):"
+              echo "Problem #$((order)):"
               echo "Compiled: $compiled"
               if [[ -n "$compilationError" && "$compilationError" != "null" ]]; then
                   echo "CompilationError: $compilationError"


### PR DESCRIPTION
Sometimes JSON data returned by server is not ordered by `order`, so using (i+1) gives wrong data in report. Using `order` is better - problems will not be ordered, but will have correct numbers.